### PR TITLE
Allow URL matching to work for mobile site

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -306,7 +306,7 @@ sub urlHandler {
 	$url =~ s/ com/.com/;
 	$url =~ s/www /www./;
 	$url =~ s/http:\/\/ /https:\/\//;
-	my ($trackhome) = $url =~ m{^https://www.mixcloud.com/(.*)$};
+	my ($subdomain, $trackhome) = $url =~ m{^https://(www|m).mixcloud.com/(.*)$};
 	my $queryUrl = "http://api.mixcloud.com/" . $trackhome ;
 
 	$log->debug("fetching $queryUrl");


### PR DESCRIPTION
m.mixcloud.com type URLs could not be matched because of the URL expecting a www subdomain.
This change to the regex fixes this.

I am not versed in Perl, so do comment if it could be done a better way.