### PR TITLE
Update Plugin.pm

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -239,7 +239,7 @@ sub tracksHandler {
 			}		
 		}
 		
-		my $queryUrl = "$method://api.mixcloud.com/$resource?offset=$i&limit=$quantity&" . $params;
+		my $queryUrl = "$method://api.mixcloud.com/$resource/?offset=$i&limit=$quantity&" . $params;
 		#$queryUrl= "http://192.168.56.1/json/cloudcasts.json";
 		$log->info("Fetching $queryUrl");
 		


### PR DESCRIPTION
MixCloud seems to have changed to require a "/" before the URL parameters. This fixes Categories but still issue with Popular/Hot - perhaps they have gone away in the service.