### PR TITLE
Do not run Github actions on merge requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,6 @@ on:
       - master
     tags:
       - '**'
-  pull_request:
-    branches:
-      - master
 
 jobs:
   build:


### PR DESCRIPTION
Commit fails on merge requests coming from other github users, so make sure it doesn't run