### PR TITLE
Prefer HTTPS to HTTP

### DIFF
--- a/HTML/EN/plugins/MixCloud/settings/basic.html
+++ b/HTML/EN/plugins/MixCloud/settings/basic.html
@@ -4,7 +4,7 @@
 	<div class="prefDesc">
 		<input type="text" class="stdedit" name="pref_apiKey" value="[% prefs.apiKey %]" size="40" />
 		<br/>
-		<a target="_blank" href="http://danielvijge.github.io/lms_mixcloud/app.html">Get your apiKey for Mixcloud at mixcloud.com</a>
+		<a target="_blank" href="https://danielvijge.github.io/lms_mixcloud/app.html">Get your apiKey for Mixcloud at mixcloud.com</a>
 	</div>
 
 	[% END %]

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -209,7 +209,7 @@ sub urlHandler {
 	$url =~ s/www /www./;
 	$url =~ s/http:\/\/ /https:\/\//;
 	my ($id) = $url =~ m{^https://(?:www|m).mixcloud.com/(.*)$};
-	my $queryUrl = "http://api.mixcloud.com/" . $id ;
+	my $queryUrl = "https://api.mixcloud.com/" . $id ;
 	return unless $id;
 
 	$log->debug("fetching $queryUrl");

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -221,7 +221,7 @@ sub fetchTrackDetails {
 		icon => __PACKAGE__->getIcon,
 	} if $client && $client->master->pluginData('fetchingMeta');
 	
-	my $fetchURL = "http://api.mixcloud.com/$id";
+	my $fetchURL = "https://api.mixcloud.com/$id";
 	$client->master->pluginData( fetchingMeta => 1 ) if $client;
 	$log->info("Getting track details for $url", dump($item));
 	

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Press the _Apply_ button and restart LMS.
 After installation, you can configure the Plugin under _Settings_ > _Advanced_ > _Mixcloud_
 
 The plugin is included as a default third party resource. It is distributed via my
-[personal repository](http://server.vijge.net/squeezebox/) This third party repository
+[personal repository](https://server.vijge.net/squeezebox/) This third party repository
 is synced with the repository XML files on GitHub. It is also possible to directly include
 the repository XML from GitHub. For the release version, include
     
-    http://danielvijge.github.io/lms_mixcloud/public.xml
+    https://danielvijge.github.io/lms_mixcloud/public.xml
 
 For the development version (updated with every commit), include
 
-    http://danielvijge.github.io/lms_mixcloud/public-dev.xml
+    https://danielvijge.github.io/lms_mixcloud/public-dev.xml
 
 This Plugin is in Alpha stage and build from the SqueezeCloud Plugin (thanks to the developers), because the documentation
 of the LMS Server is very bad and Perl still sucks.

--- a/public.template.xml
+++ b/public.template.xml
@@ -6,7 +6,7 @@
     <plugin name="MixCloud" version="{{ env['VERSION'] }}" minTarget="8.1" maxTarget="*">
       <title lang="EN">Mixcloud</title>
       <desc lang="EN">Play music from Mixcloud</desc>
-      <url>http://danielvijge.github.io/lms_mixcloud/{{ env['FOLDER'] }}/lms_mixcloud-{{ env['VERSION'] }}.zip</url>
+      <url>https://danielvijge.github.io/lms_mixcloud/{{ env['FOLDER'] }}/lms_mixcloud-{{ env['VERSION'] }}.zip</url>
       <link>https://github.com/danielvijge/lms_mixcloud</link>
       <sha>{{ env['SHA'] }}</sha>
       <creator>Christian Mueller, Daniel Vijge</creator>


### PR DESCRIPTION
Some MixCloud API calls redirect to HTTPS anyway, so we may as well save a round trip by requesting it to start with.