### PR TITLE
Explicitly call Slim::Utils::Misc::getTempDir

### DIFF
--- a/Buffered.pm
+++ b/Buffered.pm
@@ -21,7 +21,7 @@ sub new {
 	# but the switch of socket handler can only be done within _sysread otherwise
 	# we will timeout when there is a pipeline with a callback 
 	if (Slim::Utils::Misc->can('getTempDir')) { 
-		${*$self}{'_fh'} = File::Temp->new( DIR => Slim::Utils::Misc::getTempDir );
+		${*$self}{'_fh'} = File::Temp->new( DIR => Slim::Utils::Misc::getTempDir() );
 	} else {
 		${*$self}{'_fh'} = File::Temp->new;
 	}


### PR DESCRIPTION
Fixes the following on startup with perl 5.26.3:

```
[21-04-21 15:13:23.9424] Slim::bootstrap::tryModuleLoad (286) Warning: Module [Plugins::MixCloud::Plugin] failed to load:
Bareword "Slim::Utils::Misc::getTempDir" not allowed while "strict subs" in use at /var/lib/squeezeboxserver/cache/InstalledPlugins/Plugins/MixCloud/Buffered.pm line 23.
Compilation failed in require at /var/lib/squeezeboxserver/cache/InstalledPlugins/Plugins/MixCloud/ProtocolHandler.pm line 18.
BEGIN failed--compilation aborted at /var/lib/squeezeboxserver/cache/InstalledPlugins/Plugins/MixCloud/ProtocolHandler.pm line 21.
Compilation failed in require at /var/lib/squeezeboxserver/cache/InstalledPlugins/Plugins/MixCloud/Plugin.pm line 26.
BEGIN failed--compilation aborted at /var/lib/squeezeboxserver/cache/InstalledPlugins/Plugins/MixCloud/Plugin.pm line 26.
Compilation failed in require at (eval 975) line 1.
BEGIN failed--compilation aborted at (eval 975) line 1.

[21-04-21 15:13:23.9431] Slim::Utils::PluginManager::load (323) Error: Couldn't load Plugins::MixCloud::Plugin
```