### PR TITLE
Make it more obvious that path can be left blank when using system `yt-dlp`

### DIFF
--- a/HTML/EN/plugins/MixCloud/settings/basic.html
+++ b/HTML/EN/plugins/MixCloud/settings/basic.html
@@ -25,7 +25,7 @@
 	[% WRAPPER setting title="PLUGIN_MIXCLOUD_HELPER_APPLICATION" desc="PLUGIN_MIXCLOUD_HELPER_APPLICATION_DESC" %]
 		<input type="radio" class="stdedit" name="pref_helper_application" id="helper_application_bundled" value="bundled"[% IF prefs.helper_application == 'bundled' %] checked="checked"[% END %] /><label for="helper_application_bundled">[% 'PLUGIN_MIXCLOUD_HELPER_APPLICATION_BUNDLED' | getstring %]</label><br/>
 		<input type="radio" class="stdedit" name="pref_helper_application" id="helper_application_custom" value="custom"[% IF prefs.helper_application == 'custom' %] checked="checked"[% END %] /><label for="helper_application_custom">[% 'PLUGIN_MIXCLOUD_HELPER_APPLICATION_CUSTOM' | getstring %]</label><br/>
-		[% 'PLUGIN_MIXCLOUD_HELPER_APPLICATION_CUSTOM_PATH' | getstring %]: <input type="text" class="stdedit" name="pref_helper_application_custom_path" id="helper_application_custom_path" value="[% prefs.helper_application_custom_path %]" size="40" />
+		[% 'PLUGIN_MIXCLOUD_HELPER_APPLICATION_CUSTOM_PATH' | getstring %]: <input type="text" class="stdedit" name="pref_helper_application_custom_path" id="helper_application_custom_path" placeholder="yt-dlp" value="[% prefs.helper_application_custom_path %]" size="40" />
 	[% END %]
 
 [% PROCESS settings/footer.html %]

--- a/strings.txt
+++ b/strings.txt
@@ -155,13 +155,13 @@ PLUGIN_MIXCLOUD_HELPER_APPLICATION
 	EN	Helper application
 
 PLUGIN_MIXCLOUD_HELPER_APPLICATION_DESC
-	EN	This plugin uses a helper application to get a playable stream from Mixcloud. By default a bundled version of <code>yt-dlp</code> is used. Select between the bundled version of <code>yt-dlp</code>, or a custom one. If <code>yt-dlp</code> is available in <code>$PATH</code> the path field can be left empty, else enter the full path to the help application.
+	EN	This plugin uses a helper application to get a playable stream from Mixcloud. By default a bundled version of <code>yt-dlp</code> is used. Select between the bundled version of <code>yt-dlp</code>, or a custom one. If <code>yt-dlp</code> is available in <code>$PATH</code> the path field can be left empty, else enter the name of a command on <code>$PATH</code>, or the full path to the helper application.
 
 PLUGIN_MIXCLOUD_HELPER_APPLICATION_BUNDLED
 	EN	Use bundled helper application
 
 PLUGIN_MIXCLOUD_HELPER_APPLICATION_CUSTOM
-	EN	Use custom helper application
+	EN	Use system/custom helper application
 
 PLUGIN_MIXCLOUD_HELPER_APPLICATION_CUSTOM_PATH
-	EN	Full path
+	EN	Command/full path


### PR DESCRIPTION
On, e.g., Fedora, you can get an up-to-date `yt-dlp` with `dnf install yt-dlp`.  For me, it starts slightly faster than the bundled `yt-dlp`, so it is an appealing option.

This patch saves me from typing an unnecessary `/usr/bin/` when setting this up.