### PR TITLE
Tell LMS to use HTTP/1.1

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -22,6 +22,7 @@ use File::Spec::Functions qw(:ALL);
 use List::Util qw(min max);
 use Date::Parse;
 use Data::Dump qw(dump);
+use HTTP::Request;
 
 use Slim::Utils::Strings qw(string cstring);
 use Slim::Utils::Prefs;
@@ -49,6 +50,12 @@ sub getToken {
 	if ($prefs->get('apiKey')) {
 		my $tokenurl = "https://www.mixcloud.com/oauth/access_token?client_id=".$CLIENT_ID."&redirect_uri=https://danielvijge.github.io/lms_mixcloud/app.html&client_secret=".$CLIENT_SECRET."&code=".$prefs->get('apiKey');
 		$log->debug("gettokenurl: ".$tokenurl);
+		my $request = HTTP::Request->new( 'GET' => $tokenurl );
+		$request->protocol('HTTP/1.1');	# Force request because, since May 2026, seen destination rejecting HTTP/1.0 which is LMS default
+		my $params->{request} = $request;
+		my %headers;
+		$headers{'Connection'} = 'close';	# BAD BAD force close to try to prevent keep-alive in http/1.1
+		
 		Slim::Networking::SimpleAsyncHTTP->new(			
 				sub {
 					my $http = shift;				
@@ -62,8 +69,9 @@ sub getToken {
 				sub {
 					$log->error("Error: $_[1]");
 					$callback->({});
-				},			
-		)->get($tokenurl);
+				},
+				$params
+		)->get($tokenurl, %headers);
 	}else{
 		$callback->({});	
 	}
@@ -154,14 +162,14 @@ sub tracksHandler {
 	my $queryUrl;
 	if ($quantity == 1) {
         $queryUrl = "$method://api.mixcloud.com/$resource/?offset=$index&limit=$quantity" . $params;
-    } else {
+	} else {
 		$queryUrl = "$method://api.mixcloud.com/$resource/?limit=$quantity" . $params;
 	}
     
 	# Adding the token to the end of each request returns more details
 	if ($token ne '') {
-        $queryUrl .=   "&access_token=" . $token;
-    }
+		$queryUrl .=   "&access_token=" . $token;
+	}
 	
 	$log->info("Fetching $queryUrl");
 	
@@ -172,6 +180,12 @@ sub _getTracks {
 	$log->debug('_getTracks started.');
 	my ($client, $searchType, $index, $quantity, $queryUrl, $cursor, $parser, $callback, $menu, $total) = @_;
 	
+	my $request = HTTP::Request->new( 'GET' => $queryUrl );
+	$request->protocol('HTTP/1.1');	# Force request because, since May 2026, seen destination rejecting HTTP/1.0 which is LMS default
+	my $params->{request} = $request;
+	my %headers;
+	$headers{'Connection'} = 'close';	# BAD BAD force close to try to prevent keep-alive in http/1.1
+
 	Slim::Networking::SimpleAsyncHTTP->new(
 		
 		sub {
@@ -186,9 +200,9 @@ sub _getTracks {
 			if ($total eq '') {
 				# This limits search results to 400
 				$total = 400;
-            } elsif ($searchType =~ /^categories/) {
-                $total = @$menu;
-            } elsif (scalar @$menu <= $quantity ) {
+			} elsif ($searchType =~ /^categories/) {
+				$total = @$menu;
+			} elsif (scalar @$menu <= $quantity ) {
 				$total = $index + @$menu;
 				$log->debug("short page, truncate total to $total");
 			}
@@ -211,8 +225,9 @@ sub _getTracks {
 			$log->error("error: $_[1]");
 			$callback->([ { name => $_[1], type => 'text' } ]);
 		},
+		$params
 		
-	)->get($queryUrl);
+	)->get($queryUrl, %headers);
 	
 	$log->debug('_getTracks ended.');
 }
@@ -262,6 +277,12 @@ sub urlHandler {
 	return unless $id;
 
 	$log->debug("fetching $queryUrl");
+	my $request = HTTP::Request->new( 'GET' => $queryUrl );
+	$request->protocol('HTTP/1.1');	# Force request because, since May 2026, seen destination rejecting HTTP/1.0 which is LMS default
+	my $params->{request} = $request;
+	my %headers;
+	$headers{'Connection'} = 'close';	# BAD BAD force close to try to prevent keep-alive in http/1.1
+
 
 	my $fetch = sub {
 		Slim::Networking::SimpleAsyncHTTP->new(
@@ -276,7 +297,8 @@ sub urlHandler {
 				$log->error("error: $_[1]");
 				$callback->([ { name => $_[1], type => 'text' } ]);
 			},
-		)->get($queryUrl);
+			$params
+		)->get($queryUrl, %headers);
 	};
 		
 	$fetch->();
@@ -332,7 +354,7 @@ sub favoriteTrack {
 	my $method = "https";
 	my $key = $passDict->{'key'} || '';
 	my $url = $method . "://api.mixcloud.com" . $key . "favorite/?access_token=" . $token;
-    $log->debug("Favoriting: $url");
+	$log->debug("Favoriting: $url");
 
 	my $fetch = sub {
 		my $ua = LWP::UserAgent->new;
@@ -361,7 +383,7 @@ sub unfavoriteTrack {
 	my $method = "https";
 	my $key = $passDict->{'key'} || '';
 	my $url = $method . "://api.mixcloud.com" . $key . "favorite/?access_token=" . $token;
-    $log->debug("Unfavorite: $url");
+	$log->debug("Unfavorite: $url");
 
 	
 	my $fetch = sub {
@@ -395,7 +417,7 @@ sub repostTrack {
 	my $method = "https";
 	my $key = $passDict->{'key'} || '';
 	my $url = $method . "://api.mixcloud.com" . $key . "repost/?access_token=" . $token;
-    $log->debug("Reposting: $url");
+	$log->debug("Reposting: $url");
 
 	my $fetch = sub {
 		my $ua = LWP::UserAgent->new;
@@ -424,7 +446,7 @@ sub unrepostTrack {
 	my $method = "https";
 	my $key = $passDict->{'key'} || '';
 	my $url = $method . "://api.mixcloud.com" . $key . "repost/?access_token=" . $token;
-    $log->debug("Unrepost: $url");
+	$log->debug("Unrepost: $url");
 
 	
 	my $fetch = sub {
@@ -527,7 +549,7 @@ sub followUser {
 	my $method = "https";
 	my $key = $passDict->{'key'} || '';
 	my $url = $method . "://api.mixcloud.com/" . $key . "follow/?access_token=" . $token;
-    $log->debug("Following: $url");
+	$log->debug("Following: $url");
 
 	my $fetch = sub {
 		my $ua = LWP::UserAgent->new;
@@ -556,7 +578,7 @@ sub unfollowUser {
 	my $method = "https";
 	my $key = $passDict->{'key'} || '';
 	my $url = $method . "://api.mixcloud.com/" . $key . "follow/?access_token=" . $token;
-    $log->debug("Unfollowing: $url");
+	$log->debug("Unfollowing: $url");
 
 	
 	my $fetch = sub {

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -22,6 +22,7 @@ use JSON::XS::VersionOneAndTwo;
 use XML::Simple;
 use IO::Socket qw(:crlf);
 use Data::Dump qw(dump);
+use HTTP::Request;
 
 use Slim::Utils::Log;
 use Slim::Utils::Prefs;
@@ -275,7 +276,14 @@ sub getMetadataFor {
 
 		$client->pluginData( fetchingMeta => 1 ) if $client;
 		$log->info("Getting track details for $url", dump($item));
-	
+
+		my $request = HTTP::Request->new( 'GET' => $fetchURL );
+		$request->protocol('HTTP/1.1');	# Force request because, since May 2026, seen destination rejecting HTTP/1.0 which is LMS default
+		my $params->{request} = $request;
+		$params->timeout(30);
+		my %headers;
+		$headers{'Connection'} = 'close';	# BAD BAD force close to try to prevent keep-alive in http/1.1
+		
 		Slim::Networking::SimpleAsyncHTTP->new(
 		
 			sub {
@@ -289,10 +297,9 @@ sub getMetadataFor {
 				$client->pluginData( fetchingMeta => 0 ) if $client;
 				$log->error("Error fetching track metadata for $url => $_[1]");
 			},
+			$params
 		
-			{ timeout => 30 },
-		
-		)->get($fetchURL);
+		)->get($fetchURL, %headers);
 	}	
 
 	return {


### PR DESCRIPTION
Request HTTP/1.1 since remote site now responds with 426 Upgrade required when LMS default of HTTP/1.0 is used.

Also sets HTTP header "Connection" to "close" to prevent keep-alive otherwise LMS not returning short body. Not done very efficiently since this is almost identical code repeated a few times - so there is scope for tidying up.

Replaced some 4-space indents with tab to keep consistency