### PR TITLE
Switch from JSON::XS::VersionOneAndTwo to JSON::XS

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -16,7 +16,7 @@ use base qw(Slim::Plugin::OPMLBased);
 use utf8;
 
 use URI::Escape;
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS qw(decode_json);
 
 use File::Spec::Functions qw(:ALL);
 use List::Util qw(min max);
@@ -59,7 +59,7 @@ sub getToken {
 		Slim::Networking::SimpleAsyncHTTP->new(			
 				sub {
 					my $http = shift;				
-					my $json = eval { from_json($http->content) };
+					my $json = eval { decode_json($http->content) };
 					if ($json->{"access_token"}) {
 						$token = $json->{"access_token"};
 						$log->debug("token: ".$token);
@@ -190,7 +190,7 @@ sub _getTracks {
 		
 		sub {
 			my $http = shift;				
-			my $json = eval { from_json($http->content) };
+			my $json = eval { decode_json($http->content) };
 			
 			my $nextPage = $json->{'paging'}->{'next'} || '';
 			$log->debug('_getTracks next page: ' . $nextPage);
@@ -288,7 +288,7 @@ sub urlHandler {
 		Slim::Networking::SimpleAsyncHTTP->new(
 			sub {
 				my $http = shift;
-				my $item = eval { from_json($http->content) };
+				my $item = eval { decode_json($http->content) };
 				$log->warn($@) if $@;
 				my $args = { params => {isPlugin => 1}};
 				$callback->( { items => [ Plugins::MixCloud::ProtocolHandler::makeCacheItem($client, $item, $args) ] } );

--- a/ProtocolHandler.pm
+++ b/ProtocolHandler.pm
@@ -18,7 +18,7 @@ use base qw(Slim::Player::Protocols::HTTPS);
 use List::Util qw(min max);
 use HTML::Parser;
 use URI::Escape;
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS qw(decode_json);
 use XML::Simple;
 use IO::Socket qw(:crlf);
 use Data::Dump qw(dump);
@@ -222,7 +222,7 @@ sub _fetchTrackExtra {
 	my $yt_dlp_cmd = "$exec $exec_options $mixcloud_url 2>&1"; # pipe STDERR to STDOUT
 	$log->info("Executing helper binary: $yt_dlp_cmd");
 	my $info_json_str = `$yt_dlp_cmd`;
-	my $json = eval { from_json($info_json_str) };
+	my $json = eval { decode_json($info_json_str) };
 
 	if ($json) {
 		my $mixcloud_stream_url;
@@ -287,7 +287,7 @@ sub getMetadataFor {
 		Slim::Networking::SimpleAsyncHTTP->new(
 		
 			sub {
-				my $track = eval { from_json($_[0]->content) };
+				my $track = eval { decode_json($_[0]->content) };
 				$log->warn($@) if ($@);
 				makeCacheItem($client, $track, $args);
 				$client->pluginData( fetchingMeta => 0 ) if $client;


### PR DESCRIPTION
LMS no-longer uses `JSON::XS::VersionOneAndTwo` internally, and it’s simpler to use `JSON::XS` directly.